### PR TITLE
Fix byte order for aarch64 and riscv

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -306,7 +306,8 @@ MGUI_COMPILE_TIME_ASSERT(sint64, sizeof(Sint64) == 8);
  */
 #if defined(__i386__) || defined(__ia64__) || defined(__x86_64__) || defined(__amd64) || \
         (defined(__alpha__) || defined(__alpha)) || \
-        defined(__arm__) || \
+        defined(__arm__) || defined(__aarch64__) || \
+        defined(__riscv) || \
         (defined(__CC_ARM) && !defined(__BIG_ENDIAN)) || \
         (defined(__mips__) && defined(__MIPSEL__)) || \
         defined(__LITTLE_ENDIAN__) || \


### PR DESCRIPTION
The byte order of aarch64 and riscv should be little endian.